### PR TITLE
change penguin-judge plugin as default

### DIFF
--- a/bin/rime_init
+++ b/bin/rime_init
@@ -68,14 +68,21 @@ target
 
 ## You can load plugins here.
 use_plugin('rime_plus')
-use_plugin('judge_system.atcoder')
 use_plugin('judge_system.penguin')
+#use_plugin('judge_system.atcoder')
 #use_plugin('judge_system.aoj')
 #use_plugin('judge_system.hacker_rank')
 #use_plugin('wikify')
 #use_plugin('wikify_full')
 
 project(library_dir='common', required_rime_plus_version='{0}')
+
+penguin_config(
+    id="***",
+    title="***",
+    start="YYYY-MM-DDThh:mm:ss+09:00",
+    end="YYYY-MM-DDThh:mm:ss+09:00",
+)
 
 #wikify_config(
 #  url="http://example.com/pukiwiki/",
@@ -85,12 +92,13 @@ project(library_dir='common', required_rime_plus_version='{0}')
 #  auth_username="***",
 #  auth_password="***")
 
-atcoder_config(
-  upload_script='***',
-  contest_url='https://***.contest.atcoder.jp/',
-  username='***', password='***',
-  lang_ids={{'c': 13, 'cxx': 10, 'java': 3}}
-)
+#atcoder_config(
+#  upload_script='***',
+#  contest_url='https://***.contest.atcoder.jp/',
+#  username='***', password='***',
+#  lang_ids={{'c': 13, 'cxx': 10, 'java': 3}}
+#)
+
 '''.format(rime_plus_version)
     make_file('PROJECT', content)
 

--- a/rime/plugins/plus/commands.py
+++ b/rime/plugins/plus/commands.py
@@ -93,21 +93,24 @@ class Project(targets.registry.Project):
             content = '''\
 # -*- coding: utf-8; mode: python -*-
 
-pid='X'
-
 problem(
-  time_limit=1.0,
-  id=pid,
-  title=pid + ": Your Problem Name",
+  time_limit=5,
+  id="***",
+  title="Your Problem Name",
+  #reference_solution='???',
   #wiki_name="Your pukiwiki page name", # for wikify plugin
   #assignees=['Assignees', 'for', 'this', 'problem'], # for wikify plugin
   #need_custom_judge=True, # for wikify plugin
-  #reference_solution='???',
-  )
-
-atcoder_config(
-  task_id=None # None means a spare
 )
+
+penguin_config(
+  memory_limit=512,
+  score=100,
+)
+
+#atcoder_config(
+#  task_id=None # None means a spare
+#)
 '''
             newdir = os.path.join(self.base_dir, name)
             if(os.path.exists(newdir)):


### PR DESCRIPTION
rime_init, rime add コマンドを叩いたときに生成されるテンプレートがすぐにPenguinJudgeで使えるように変更しました。